### PR TITLE
add typemap parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,32 @@ memory usage: 179.0 bytes
 >>> 
 ```
 
+#### Adding custom type mappings to `create_table_schema_pairs`
+```python
+>>> df = pd.DataFrame(data, columns = ['First Name', 'Age In Years'])
+
+>>> enforce_sql_column_names(df, inplace=True)
+
+>>> df.info(verbose=True)
+<class 'pandas.core.frame.DataFrame'>
+RangeIndex: 3 entries, 0 to 2
+Data columns (total 2 columns):
+ #   Column        Non-Null Count  Dtype 
+---  ------        --------------  ----- 
+ 0   first_name    3 non-null      object
+ 1   age_in_years  3 non-null      int64 
+dtypes: int64(1), object(1)
+memory usage: 176.0+ bytes
+
+>>> p = create_table_schema_pairs(df, typemap={'object':'varchar'})
+
+>>> print(p)
+    first_name varchar,
+    age_in_years bigint
+
+>>>
+```
+
 ### build and upload a new release
 
 - update all occurrences of `__version__`

--- a/osc_ingest_trino/sqltypes.py
+++ b/osc_ingest_trino/sqltypes.py
@@ -19,19 +19,22 @@ _p2smap = {
     'datetime64[ns, UTC]': 'timestamp',
 }
 
-def pandas_type_to_sql(pt):
-    st = _p2smap.get(pt)
+def pandas_type_to_sql(pt, typemap={}):
+    if not isinstance(typemap, dict):
+        raise ValueError("typemap must be a dict")
+    # user defined typemap overrides _p2smap
+    st = typemap.get(pt, _p2smap.get(pt))
     if st is not None:
         return st
     raise ValueError("unexpected pandas column type '{pt}'".format(pt=pt))
 
 # add ability to specify optional dict for specific fields?
 # if column name is present, use specified value?
-def create_table_schema_pairs(df):
+def create_table_schema_pairs(df, typemap={}):
     if not isinstance(df, pd.DataFrame):
         raise ValueError("df must be a pandas DataFrame")
     ptypes = [str(e) for e in df.dtypes.to_list()]
-    stypes = [pandas_type_to_sql(e) for e in ptypes]
+    stypes = [pandas_type_to_sql(e, typemap=typemap) for e in ptypes]
     pz = list(zip(df.columns.to_list(), stypes))
     return ",\n".join(["    {n} {t}".format(n=e[0],t=e[1]) for e in pz])
 


### PR DESCRIPTION
fix #2
adds workaround for #1

Adds a `typemap` parameter where a user can supply additional mappings from pandas types to
sql column types.

Example usage:

```python
>>> df = pd.DataFrame(data, columns = ['First Name', 'Age In Years'])

>>> enforce_sql_column_names(df, inplace=True)

>>> df.info(verbose=True)
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 3 entries, 0 to 2
Data columns (total 2 columns):
 #   Column        Non-Null Count  Dtype 
---  ------        --------------  ----- 
 0   first_name    3 non-null      object
 1   age_in_years  3 non-null      int64 
dtypes: int64(1), object(1)
memory usage: 176.0+ bytes

>>> p = create_table_schema_pairs(df, typemap={'object':'varchar'})

>>> print(p)
    first_name varchar,
    age_in_years bigint

>>>
```