### PR TITLE
Cleanup tmp

### DIFF
--- a/osc_ingest_trino/__init__.py
+++ b/osc_ingest_trino/__init__.py
@@ -5,7 +5,7 @@ python tools to assist with standardized data ingestion workflows for the OS-Cli
 """
 
 # defines the release version for this python package
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 from .sqlcols import *
 from .sqltypes import *

--- a/osc_ingest_trino/trino_utils.py
+++ b/osc_ingest_trino/trino_utils.py
@@ -91,6 +91,8 @@ def ingest_unmanaged_parquet(df, schema, table, bucket, partition_columns=[], ap
                       index=False)
         # upload the tree onto S3
         upload_directory_to_s3(tmp, bucket, s3pfx, verbose=verbose)
+        if tmp.startswith('/tmp/'):
+            os.rmdir(tmp)
     else:
         # do not use partitions: a single parquet file is created
         parquet = f'{uuid.uuid4().hex}.parquet'
@@ -99,6 +101,10 @@ def ingest_unmanaged_parquet(df, schema, table, bucket, partition_columns=[], ap
         dst = f'{s3pfx}/{parquet}'
         if verbose: print(f'{tmp}  -->  {dst}')
         bucket.upload_file(tmp, dst)
+        if tmp.startswith('/tmp/'):
+            os.remove(tmp)
+    if verbose and tmp.startswith('/tmp/'):
+        print(f"removed {tmp}")
 
 def unmanaged_parquet_tabledef(df, catalog, schema, table, bucket,
                                partition_columns = [],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name = "osc-ingest-tools",
-    version = "0.2.1",
+    version = "0.2.2",
     description = "python tools to assist with standardized data ingestion workflows for the OS-Climate project",
     long_description = README,
     long_description_content_type = "text/markdown",


### PR DESCRIPTION
This pull request checks if we used /tmp storage for converting DF to PARQUET.  If so, clean up the files so that /tmp doesn't fill up. 

And bump version number.