### PR TITLE
Setup tox testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+addopts = "-v"
+
+[tool.mypy]
+warn_unreachable = true
+ignore_missing_imports = true
+
+[tool.black]
+line-length = 120
+exclude = '''
+/(
+    \.git
+  | \.tox
+  | \venv
+  | \.venv
+  | \*.env
+  | \build
+  | \dist
+)/
+'''
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 120
+
+[tool.coverage.run]
+source = "src"
+omit = "tests/*"
+relative_files = true

--- a/tests/test_trino_utils.py
+++ b/tests/test_trino_utils.py
@@ -1,0 +1,20 @@
+import mock
+from osc_ingest_trino import attach_trino_engine
+
+
+@mock.patch("osc_ingest_trino.trino_utils.trino.auth.JWTAuthentication")
+@mock.patch("osc_ingest_trino.trino_utils.create_engine")
+def test_attach_trino_engine(mock_engine, mock_trino_auth, monkeypatch):
+    monkeypatch.setenv("TEST_USER", "tester")
+    monkeypatch.setenv("TEST_PASSWD", "supersecret123")
+    monkeypatch.setenv("TEST_HOST", "example")
+    monkeypatch.setenv("TEST_PORT", "8000")
+
+    fake_engine = mock.MagicMock()
+    fake_engine.connect.return_value = None
+    mock_engine.return_value = fake_engine
+    mock_trino_auth.return_value = "yep"
+
+    attach_trino_engine(env_var_prefix="TEST", catalog="ex_catalog", schema="ex_schema", verbose=True)
+
+    mock_engine.assert_called_with("trino://tester@example:8000/ex_catalog/ex_schema", connect_args={'auth': 'yep', 'http_scheme': 'https'})

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,36 @@
+[tox]
+envlist = py38, static
+
+[testenv]
+deps =
+    mock
+    pytest
+commands = pytest {posargs}
+
+[testenv:static]
+deps =
+    mypy
+    isort
+    black
+    flake8
+commands =
+    mypy --install-types --non-interactive osc_ingest_trino
+    isort --check .
+    black --check .
+    flake8 src
+
+[testenv:cov]
+usedevelop = True
+deps =
+    pytest-cov
+commands = pytest --cov-report=html {posargs}
+
+[flake8]
+count = True
+max-line-length = 120
+max-complexity = 10
+# Allow __init__ files to have unused imports.
+per-file-ignores = __init__.py:F401
+extend-ignore =
+    # Allow spacing before colon (to favor Black).
+    E203


### PR DESCRIPTION
Added tox.ini, an initial unit test, and supporting configuration.

Developers may now execute tox jobs;
- `tox -e py3`: runs pytest in a Python 3 environment
- `tox -e static`: runs static checks (black, isort, flake8, mypy)
- `tox -e cov`: runs pytest and produces an HTML coverage report
- `tox`: runs all environment listed in 'envlist' (py38, static)

Signed-off-by: Nathan Gillett <ngillett@redhat.com>