### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+---
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 22.1.0
+    hooks:
+    - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8
+      additional_dependencies:
+        - pep8-naming
+      # Ignore all format-related checks as Black takes care of those.
+      args:
+        - --ignore=E2, W5, F401, E401
+        - --select=E, W, F, N
+        - --max-line-length=120

--- a/README.md
+++ b/README.md
@@ -92,13 +92,22 @@ https://github.com/os-climate/osc-ingest-tools.
 All changes must pass the automated test suite, along with various static
 checks.
 
-The [Black](https://black.readthedocs.io/) code style is enforced.
+[Black](https://black.readthedocs.io/) code style and
+[isort](https://pycqa.github.io/isort/) import ordering are enforced.
+
+Enabling automatic formatting via [pre-commit](https://pre-commit.com/) is
+recommended:
+```
+pip install black isort pre-commit
+pre-commit install
+```
+
 To ensure compliance with static check tools, developers may wish to run;
 ```
 pip install black isort
 # auto-sort imports
 isort .
-# auto-format
+# auto-format code
 black .
 ```
 


### PR DESCRIPTION
Developers may now enable pre-commit to automatically format and check
code upon `git commit`.

Signed-off-by: Nathan Gillett <ngillett@redhat.com>