### PR TITLE
Add support for more value types in TrinoBatchInsert

### DIFF
--- a/osc_ingest_trino/sqltypes.py
+++ b/osc_ingest_trino/sqltypes.py
@@ -16,6 +16,7 @@ _p2smap = {
     "int64": "bigint",
     "Int64": "bigint",
     "bool": "boolean",
+    "boolean": "boolean",
     "category": "varchar",
     "datetime64[ns, UTC]": "timestamp",
 }

--- a/osc_ingest_trino/trino_utils.py
+++ b/osc_ingest_trino/trino_utils.py
@@ -100,7 +100,7 @@ class TrinoBatchInsert(object):
         if isinstance(x, datetime):
             return f"TIMESTAMP '{x}'"
         if math.isnan(x):
-            return f"nan()"
+            return "nan()"
         return str(x)
 
     @staticmethod

--- a/osc_ingest_trino/trino_utils.py
+++ b/osc_ingest_trino/trino_utils.py
@@ -3,6 +3,7 @@ import os
 import trino
 from sqlalchemy.engine import create_engine
 from sqlalchemy.sql import text
+from datetime import datetime
 
 __all__ = [
     "attach_trino_engine",
@@ -95,6 +96,8 @@ class TrinoBatchInsert(object):
             t = x.replace("'", "''")
             # enclose string with single quotes
             return f"'{t}'"
+        if isinstance(x, datetime):
+            return f"TIMESTAMP '{x}'"
         return str(x)
 
     @staticmethod

--- a/osc_ingest_trino/trino_utils.py
+++ b/osc_ingest_trino/trino_utils.py
@@ -1,3 +1,4 @@
+import math
 import os
 from datetime import datetime
 
@@ -98,6 +99,8 @@ class TrinoBatchInsert(object):
             return f"'{t}'"
         if isinstance(x, datetime):
             return f"TIMESTAMP '{x}'"
+        if x is None: # math.isnan(x):
+            return f"nan()"
         return str(x)
 
     @staticmethod

--- a/osc_ingest_trino/trino_utils.py
+++ b/osc_ingest_trino/trino_utils.py
@@ -1,9 +1,9 @@
 import os
+from datetime import datetime
 
 import trino
 from sqlalchemy.engine import create_engine
 from sqlalchemy.sql import text
-from datetime import datetime
 
 __all__ = [
     "attach_trino_engine",

--- a/osc_ingest_trino/trino_utils.py
+++ b/osc_ingest_trino/trino_utils.py
@@ -99,7 +99,7 @@ class TrinoBatchInsert(object):
             return f"'{t}'"
         if isinstance(x, datetime):
             return f"TIMESTAMP '{x}'"
-        if x is None: # math.isnan(x):
+        if math.isnan(x):
             return f"nan()"
         return str(x)
 

--- a/osc_ingest_trino/trino_utils.py
+++ b/osc_ingest_trino/trino_utils.py
@@ -92,6 +92,8 @@ class TrinoBatchInsert(object):
 
     @staticmethod
     def _sqlform(x):
+        if x is None:
+            return "NULL"
         if isinstance(x, str):
             # escape any single quotes in the string
             t = x.replace("'", "''")
@@ -99,8 +101,13 @@ class TrinoBatchInsert(object):
             return f"'{t}'"
         if isinstance(x, datetime):
             return f"TIMESTAMP '{x}'"
-        if math.isnan(x):
-            return "nan()"
+        if isinstance(x, float):
+            if math.isnan(x):
+                return "nan()"
+            if math.isinf(x):
+                if x < 0:
+                    return "-infinity()"
+                return "infinity()"
         return str(x)
 
     @staticmethod


### PR DESCRIPTION
Seems needed by Trino:

Works:
  ('Exelon Corp.', 'Commonwealth Edison Co.', 32, TIMESTAMP '2015-01-01 00:00:00', 'nuclear', 'non_fuel_operation_expenses', 'electric expenses', 0.0, 0.0)

Fails:
  ('Exelon Corp.', 'Commonwealth Edison Co.', 32, 2015-01-01 00:00:00, 'nuclear', 'non_fuel_operation_expenses', 'electric expenses', 0.0, 0.0)