### PR TITLE
Ingest tables without partitions (fix-38)

### DIFF
--- a/osc_ingest_trino/trino_utils.py
+++ b/osc_ingest_trino/trino_utils.py
@@ -111,8 +111,9 @@ def fast_pandas_ingest_via_hive(  # noqa: C901
 
     if verbose:
         print("\nsyncing partition metadata on intermediate hive table")
-    sql = text(f"call {hive_catalog}.system.sync_partition_metadata('{hive_schema}', '{hive_table}', 'FULL')")
-    _do_sql(sql, engine, verbose=verbose)
+    if len(partition_columns) > 0:
+        sql = text(f"call {hive_catalog}.system.sync_partition_metadata('{hive_schema}', '{hive_table}', 'FULL')")
+        _do_sql(sql, engine, verbose=verbose)
 
     if overwrite:
         if verbose:


### PR DESCRIPTION
Don't call sync_partition_metadata if the table has no partitions.

Signed-off-by: MichaelTiemannOSC <mtiemann@os-climate.org>