### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
       ### SIGNING ###
 
       - name: "Sign packages with Sigstore"
-        uses: sigstore/gh-action-sigstore-python@latest
+        uses: sigstore/gh-action-sigstore-python@v2
         with:
           inputs: >-
             ./dist/*.tar.gz
@@ -85,20 +85,6 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           path: dist/
-
-      - name: "📦 Publish release to GitHub"
-        uses: ModeSevenIndustrialSolutions/action-automatic-releases@latest
-        with:
-          # Valid inputs are:
-          # repo_token, automatic_release_tag, draft, prerelease, title, files
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: false
-          automatic_release_tag: ${{ github.ref_name }}
-          title: ${{ github.ref_name }}
-          files: |
-            dist/*.tar.gz
-            dist/*.whl
-            dist/*.sigstore
 
       - name: "📦 Publish artefacts to GitHub"
         # https://github.com/softprops/action-gh-release

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -62,7 +62,7 @@ jobs:
       ### SIGNING ###
 
       - name: "Sign packages with Sigstore"
-        uses: sigstore/gh-action-sigstore-python@latest
+        uses: sigstore/gh-action-sigstore-python@v2
         with:
           inputs: >-
             ./dist/*.tar.gz


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit