### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
       ### SIGNING ###
 
       - name: "Sign packages with Sigstore"
-        uses: sigstore/gh-action-sigstore-python@v2
+        uses: sigstore/gh-action-sigstore-python@v2.1.5
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -62,7 +62,7 @@ jobs:
       ### SIGNING ###
 
       - name: "Sign packages with Sigstore"
-        uses: sigstore/gh-action-sigstore-python@v2
+        uses: sigstore/gh-action-sigstore-python@v2.1.5
         with:
           inputs: >-
             ./dist/*.tar.gz


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit